### PR TITLE
do not execute idga update when limit ad tracking

### DIFF
--- a/SurveyonPartners/SurveyonPartners.swift
+++ b/SurveyonPartners/SurveyonPartners.swift
@@ -39,6 +39,12 @@ extension SurveyonPartners {
                            idfaUpdateSpan: updateSpan,
                            useHttps: useHttps,
                            verifyHost: verifyHost))
+    
+    if #available(iOS 10.0, *) {
+      if !AdvertisingId.getIsAdvertisingTrackingEnabled() {
+        return
+      }
+    }
 
     if (isNeedAdIdUpdated(currentTimeMilles: Utility.currentTimeMillis())) {
       updateIdfa()


### PR DESCRIPTION
- Do not execute idfa update API when limit ad tracking is on, on iOS 10 or higher