### PR TITLE
Add app name and app version to user agent

### DIFF
--- a/SurveyonPartners.podspec
+++ b/SurveyonPartners.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SurveyonPartners"
-  s.version      = "0.0.8"
+  s.version      = "0.0.9"
   s.summary      = "SOP iOS SDK"
 
   s.description  = <<-DESC

--- a/SurveyonPartners.xcodeproj/xcshareddata/xcschemes/SurveyonPartners.xcscheme
+++ b/SurveyonPartners.xcodeproj/xcshareddata/xcschemes/SurveyonPartners.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E15B61B1E5EBA5C00FE0671"
+               BuildableName = "SurveyonPartners.framework"
+               BlueprintName = "SurveyonPartners"
+               ReferencedContainer = "container:SurveyonPartners.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E15B6241E5EBA5C00FE0671"
+               BuildableName = "SurveyonPartnersTests.xctest"
+               BlueprintName = "SurveyonPartnersTests"
+               ReferencedContainer = "container:SurveyonPartners.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E15B61B1E5EBA5C00FE0671"
+            BuildableName = "SurveyonPartners.framework"
+            BlueprintName = "SurveyonPartners"
+            ReferencedContainer = "container:SurveyonPartners.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E15B61B1E5EBA5C00FE0671"
+            BuildableName = "SurveyonPartners.framework"
+            BlueprintName = "SurveyonPartners"
+            ReferencedContainer = "container:SurveyonPartners.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E15B61B1E5EBA5C00FE0671"
+            BuildableName = "SurveyonPartners.framework"
+            BlueprintName = "SurveyonPartners"
+            ReferencedContainer = "container:SurveyonPartners.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SurveyonPartners.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SurveyonPartners.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SurveyonPartners/HttpClient.swift
+++ b/SurveyonPartners/HttpClient.swift
@@ -46,6 +46,10 @@ struct HttpClient {
   var useHttps: Bool
   
   var verifyHost: Bool
+  
+  var appVersion: String?
+    
+  var appName: String?
 
   init(appId: String,
        appMid: String,
@@ -54,7 +58,9 @@ struct HttpClient {
        sopConsoleHost: String,
        updateSpan: Int64,
        useHttps: Bool,
-       verifyHost: Bool) {
+       verifyHost: Bool,
+       appVersion: String? = nil,
+       appName: String? = nil ) {
     self.appId = appId
     self.appMid = appMid
     self.secretKey = secretKey
@@ -63,6 +69,8 @@ struct HttpClient {
     self.idfaUpdateSpan = updateSpan
     self.useHttps = useHttps
     self.verifyHost = verifyHost
+    self.appVersion = appVersion
+    self.appName = appName
   }
 }
 
@@ -95,8 +103,7 @@ extension HttpClient {
       request.addHeader(key: Request.CONTENT_TYPE, value: Request.APPLICATION_JSON)
       request.addHeader(key: Request.X_SOP_SIG,
                         value: Authentication().createSignature(message: JSONString, key: secretKey))
-      request.addHeader(key: Request.USER_AGENT, value: Utility.getUserAgent())
-
+      request.addHeader(key: Request.USER_AGENT, value: Utility.getUserAgent(appName: self.appName, appVersion: self.appVersion))
       request.post(completion: completion)
     }
   }
@@ -130,6 +137,7 @@ extension HttpClient {
     let request = Request(url: url,
                           httpMethod: .GET,
                           verifyHost: verifyHost)
+    request.addHeader(key: Request.USER_AGENT, value: Utility.getUserAgent(appName: self.appName, appVersion: self.appVersion))
     request.get(completion: completion)
   }
   

--- a/SurveyonPartners/SurveyonPartners.h
+++ b/SurveyonPartners/SurveyonPartners.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-//! Project version number for SurveyonPartners.
+//! Project version number fwor SurveyonPartners.
 FOUNDATION_EXPORT double SurveyonPartnersVersionNumber;
 
 //! Project version string for SurveyonPartners.

--- a/SurveyonPartners/SurveyonPartners.h
+++ b/SurveyonPartners/SurveyonPartners.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-//! Project version number fwor SurveyonPartners.
+//! Project version number for SurveyonPartners.
 FOUNDATION_EXPORT double SurveyonPartnersVersionNumber;
 
 //! Project version string for SurveyonPartners.

--- a/SurveyonPartners/SurveyonPartners.swift
+++ b/SurveyonPartners/SurveyonPartners.swift
@@ -36,7 +36,9 @@ extension SurveyonPartners {
 
   public static func setUp(appId: String,
                            appMid: String,
-                           secretKey: String) {
+                           secretKey: String,
+                           appVersion: String? = nil,
+                           appName: String? = nil ) {
 
     let host = getFromPlist(key: sopHostKey, defaultValue: DEFAULT_SOP_HOST)
     let consoleHost = getFromPlist(key: sopConsoleHostKey, defaultValue: DEFAULT_SOP_CONSOLE_HOST)
@@ -51,7 +53,9 @@ extension SurveyonPartners {
                      sopConsoleHost: consoleHost,
                      idfaUpdateSpan: updateSpan,
                      useHttps: useHttps,
-                     verifyHost: verifyHost))
+                     verifyHost: verifyHost,
+                     appVersion: appVersion,
+                     appName: appName))
 
     if (isNeedAdIdUpdated(currentTimeMilles: Utility.currentTimeMillis())) {
       updateIdfa()
@@ -77,7 +81,9 @@ extension SurveyonPartners {
                                 sopConsoleHost: config.sopConsoleHost,
                                 updateSpan: config.idfaUpdateSpan,
                                 useHttps: config.useHttps,
-                                verifyHost: config.verifyHost)
+                                verifyHost: config.verifyHost,
+                                appVersion: config.appVersion,
+                                appName: config.appName)
     httpClient.getSurveyList(completion: completion)
   }
 
@@ -119,7 +125,9 @@ extension SurveyonPartners {
                                 sopConsoleHost: config.sopConsoleHost,
                                 updateSpan: config.idfaUpdateSpan,
                                 useHttps: config.useHttps,
-                                verifyHost: config.verifyHost)
+                                verifyHost: config.verifyHost,
+                                appVersion: config.appVersion,
+                                appName: config.appName)
     
     httpClient.updateIdfa(completion: { (result) -> Void in
       switch result {

--- a/SurveyonPartners/Utility.swift
+++ b/SurveyonPartners/Utility.swift
@@ -10,6 +10,11 @@ import SystemConfiguration
 final class Utility {
   
   static func getUserAgent(appName: String? = nil, appVersion: String? = nil) -> String {
+    
+    if let aName = appName, let aVersion = appVersion {
+      return aName + " " + aVersion + " (" + getDeviceInfo() + ")"
+    }
+    
     var version: String = ""
     
     if let bundle = SurveyonPartners.getResourceBundle(),
@@ -17,10 +22,8 @@ final class Utility {
        let tmpVersion = obj as? String {
       version = tmpVersion
     }
-    let aName = appName ?? "sop-ios-sdk" // when appName is nil, set sop-ios-sdk
-    let aVersion = appVersion ?? version //when appVersion is nil, set SOP SDK version
-
-    return aName + " " + aVersion + " (" + getDeviceInfo() + ")"
+    
+    return "sop-ios-sdk" + " " + version + " (" + getDeviceInfo() + ")"
   }
   
   static func getDeviceInfo() -> String {

--- a/SurveyonPartners/Utility.swift
+++ b/SurveyonPartners/Utility.swift
@@ -9,15 +9,17 @@ import SystemConfiguration
 
 final class Utility {
   
-  static func getUserAgent() -> String {
+  static func getUserAgent(appName: String? = nil, appVersion: String? = nil) -> String {
     var version: String = ""
-    if let bundle = Bundle(identifier: "com.surveyon.partners.SurveyonPartners"),
-       let obj = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString"),
+    let bundle = Bundle(for: SurveyonPartners.self)
+    if let obj = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString"),
        let tmpVersion = obj as? String {
       version = tmpVersion
     }
+    let aName = appName ?? "sop-ios-sdk" // when appName is nil, set sop-ios-sdk
+    let aVersion = appVersion ?? version //when appVersion is nil, set SOP SDK version
 
-    return "sop-android-sdk/" + version + " (" + getDeviceInfo() + ")"
+    return aName + " " + aVersion + " (" + getDeviceInfo() + ")"
   }
   
   static func getDeviceInfo() -> String {

--- a/SurveyonPartners/Utility.swift
+++ b/SurveyonPartners/Utility.swift
@@ -11,8 +11,9 @@ final class Utility {
   
   static func getUserAgent(appName: String? = nil, appVersion: String? = nil) -> String {
     var version: String = ""
-    let bundle = Bundle(for: SurveyonPartners.self)
-    if let obj = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString"),
+    
+    if let bundle = SurveyonPartners.getResourceBundle(),
+       let obj = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString"),
        let tmpVersion = obj as? String {
       version = tmpVersion
     }

--- a/SurveyonPartners/models/Config.swift
+++ b/SurveyonPartners/models/Config.swift
@@ -22,6 +22,10 @@ struct Config {
   let useHttps: Bool
   
   let verifyHost: Bool
+    
+  var appVersion: String?
+    
+  var appName: String?
   
   init(appId: String,
        appMid: String,
@@ -30,7 +34,9 @@ struct Config {
        sopConsoleHost: String,
        idfaUpdateSpan: Int64,
        useHttps: Bool,
-       verifyHost: Bool) {
+       verifyHost: Bool,
+       appVersion: String? = nil,
+       appName: String? = nil ) {
     self.appId = appId
     self.appMid = appMid
     self.secretKey = secretKey
@@ -39,5 +45,7 @@ struct Config {
     self.idfaUpdateSpan = idfaUpdateSpan
     self.useHttps = useHttps
     self.verifyHost = verifyHost
+    self.appVersion = appVersion
+    self.appName = appName
   }
 }

--- a/SurveyonPartnersTests/UtilityTests.swift
+++ b/SurveyonPartnersTests/UtilityTests.swift
@@ -12,7 +12,7 @@ class UtilityTests: XCTestCase {
 
   func testGetUserAgent() {
     let userAgent = Utility.getUserAgent()
-    let re = try? NSRegularExpression(pattern: "sop-android-sdk/\\d+?[.]\\d+?[.]\\d+? \\(.+?\\)")
+    let re = try? NSRegularExpression(pattern: "sop-ios-sdk\\d+?[.]\\d+?[.]\\d+? \\(.+?\\)")
     let number = re?.numberOfMatches(in: userAgent, range: NSMakeRange(0, userAgent.characters.count))
     XCTAssertEqual(number, 1)
   }


### PR DESCRIPTION
## Cause

SOP need user-agent to control some research surveys show or hide.

## Changes

* [ ] Upgrade SOP SDK `0.0.8` to `0.0.9`
* [ ] Add two optional variables ( `appName` and `appVersion` ) to SOP SDK setUp method.
* [ ] Add appName and appVersion to user-agent, if they are existing.
* [ ] Add `user-agent` to surveylist request.


